### PR TITLE
Create, update, and destroy added to Comment viewset

### DIFF
--- a/rareapi/views/comments.py
+++ b/rareapi/views/comments.py
@@ -1,7 +1,9 @@
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
-from rareapi.models import Comment
+from django.forms import ValidationError
+from rareapi.models import Comment, RareUser
+
 
 class CommentView(ViewSet):
     def list (self, request):
@@ -9,7 +11,7 @@ class CommentView(ViewSet):
         comments = Comment.objects.order_by('-created_on')
         serializer = CommentSerializer(comments, many=True)
         return Response(serializer.data)
-    
+
     def retrieve(self, request, pk):
         """handles the GET for single comments"""
         try:
@@ -18,9 +20,40 @@ class CommentView(ViewSet):
             return Response(serializer.data)
         except Comment.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-    
+
+    def create(self, request):
+        author = RareUser.objects.get(user=request.auth.user)
+        try:
+            serializer = CreateCommentSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save(author=author)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except ValidationError as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+    def update(self, request, pk):
+        try:
+            post_comment = Comment.objects.get(pk=pk)
+            serializer = CreateCommentSerializer(post_comment, data=request.data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+        except ValidationError as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+    def destroy(self, request, pk):
+        post_comment = Comment.objects.get(pk=pk)
+        post_comment.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = ('id', 'content', 'created_on', 'author', 'post')
         depth = 2
+
+class CreateCommentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ('content', 'created_on', 'post')
+        


### PR DESCRIPTION
# Description

I added create, update, and delete methods to the CommentView.

Fixes #7 #22 #23 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In postman, run a POST on `http://localhost:8000/comments`
(run a GET first on the same URL if you need a reference for the JSON body)

In postman, run a PUT on `http://localhost:8000/comments/{comment.id}`
in the body section, make sure raw and JSON are selected from the dropdowns
the comment object will only use the content, post, and created_on fields.
(run a GET on the same URL from above if you need to copy/paste the values)
hitting send should return a 204 and if you run a GET you should see any changes you made reflected in the new list.

In postman, run a DELETE on `http://localhost:8000/comments/{comment.id}`
hit send and if the if you used in the url is  the id of an object in the comments database, it will remove the whole object from the database
Run a GET afterwards to verify.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
