### PR TITLE
image saves to postpics folder and posts with now post

### DIFF
--- a/rareapi/models/post.py
+++ b/rareapi/models/post.py
@@ -8,7 +8,9 @@ class Post(models.Model):
     category = models.ForeignKey("Category", on_delete=models.DO_NOTHING)
     title = models.CharField(max_length=100)
     publication_date = models.DateField(auto_now_add=True)
-    image_url = models.URLField()
+    image_url = models.ImageField(
+        upload_to='postpics', height_field=None,
+        width_field=None, max_length=None, null=True)
     content = models.TextField()
     approved = models.BooleanField(default=False)
     tags = models.ManyToManyField("Tag", through="PostTag", related_name="tags")


### PR DESCRIPTION
# Description

An images can now be uploaded and saved to the api with any new post thats created

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Login as an author or admin
create a post and click the upload file button to upload a picture.
click save and then wait until post is approved. 
on the image details page the image should display in the header section

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
